### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Works with any MCP-compatible AI tool:
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ladislavsopko-mcp-ai-server-visual-studio).
+
 ## Quick Start
 
 1. **[Install](https://marketplace.visualstudio.com/items?itemName=LadislavSopko.mcpserverforvs)** from Visual Studio Marketplace


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ladislavsopko-mcp-ai-server-visual-studio)